### PR TITLE
Add HTML support

### DIFF
--- a/elf_size_analyze/__main__.py
+++ b/elf_size_analyze/__main__.py
@@ -30,6 +30,7 @@ from elf_size_analyze.symbol import (Symbol, add_fileinfo_to_symbols,
                                      demangle_symbol_names,
                                      extract_elf_symbols_fileinfo)
 from elf_size_analyze.symbol_tree import SymbolsTreeByPath
+from elf_size_analyze.html_output import generate_html_output
 
 # default logging configuration
 log = logging.getLogger('elf-size-analyze')
@@ -108,6 +109,14 @@ def main():
             
         print(json.dumps(nodedict))
 
+    def print_html(header, tree):
+        min_size = math.inf if args.files_only else args.min_size
+        nodedict = tree._generate_node_dict(min_size=min_size)
+        title = f"ELF size information for {os.path.basename(args.elf)} - {header}"
+        html = generate_html_output(nodedict, title, args.css)
+        print(html)
+
+
     def filter_symbols(section_key):
         secs = filter(section_key, sections)
         secs_str = ', '.join(s.name for s in secs)
@@ -127,6 +136,7 @@ ERROR: No symbols from given section found or all were ignored!
         Section.print(sections)
 
     print_func = print_json if args.json else print_tree
+    print_func = print_html if args.html else print_tree
 
     if args.rom:
         print_func('ROM', prepare_tree(filter_symbols(lambda sec: sec and sec.occupies_rom())))

--- a/elf_size_analyze/argument_parser.py
+++ b/elf_size_analyze/argument_parser.py
@@ -66,7 +66,11 @@ sections must have ALLOC flag and: for RAM - have WRITE flag, for ROM - not have
     printing_group.add_argument('-a', '--alternating-colors', action='store_true',
                                 help='use alternating colors when printing symbols')
     printing_group.add_argument('-j', '--json', action='store_true',
-                                help='create json output')                           
+                                help='create json output')
+    printing_group.add_argument('-W', '--html', action='store_true',
+                                help='create HTML output')
+    printing_group.add_argument('-c', '--css',
+                                help='path to custom css for HTML output')                                
 
     printing_group.add_argument('--no-demangle', action='store_true',
                                 help='disable demangling of C++ symbol names')

--- a/elf_size_analyze/html_output.py
+++ b/elf_size_analyze/html_output.py
@@ -1,0 +1,76 @@
+"""
+Generator functions for HTML output
+"""
+
+
+def generate_html_output(node_dict, title, custom_css = None):
+    table_content = ""
+
+    _css_style = """
+                tr:nth-child(even) {
+                    background-color: #efefef;
+                }
+                tr:nth-child(odd) {
+                    background-color: #e0e0e0;
+                }
+                table {
+                    border-spacing: 0px;
+                    table-layout:fixed;
+                    width: 100%;
+                }
+                h3 {
+                    font-family: "Verdana";
+                    font-size: 14pt;
+                }
+                td {
+                    font-family: "Verdana";
+                    font-size: 10pt;
+                }
+                tr:hover {
+                    background: #adf0c2 !important;
+                }
+    """
+
+    def _print_children(node, level=0):
+        nonlocal table_content
+        for x, y in node.items():
+            table_content += f"""
+            <tr>
+                <td style='padding-left:{10*level}px;word-break:break-all;word-wrap:break-word'>{x}</td>
+                <td width='200px' align='right'>{y['cumulative_size']}</td>
+            </tr>
+    """
+            
+            if "children" in y:
+                _print_children(y["children"], level + 1)
+        
+    _print_children(node_dict)
+    
+    overall_size = 0
+    for x,y in node_dict.items():
+        overall_size = overall_size + y["cumulative_size"]
+
+    if custom_css:
+        with open(custom_css) as style_file:
+            _css_style = style_file.read()
+
+    html_output = f"""<!DOCTYPE html>
+<html>
+    <head>
+        <title>{title}</title>
+        <style>{_css_style}
+        </style>
+    </head>
+    <body>
+        <h3>{title}</h3>
+        <table>{table_content}
+            <tr>
+                <td align="right"><b>Overall size in bytes</b></td>
+                <td align="right">{overall_size}</td>
+            </tr>
+        </table>
+    </body>
+</html>
+"""
+
+    return html_output


### PR DESCRIPTION
This PR enables elf-size-analyze to create HTML output.

E.g., for creating a HTML table with the flash sizes, one can simply run elf-size-analyze with
`python -m elf_size_analyze Sample.elf -F -W > test.html` which will create the specified HTML file with the flash size content.

You can also provide a custom style-sheet with `-c <CUSTOM CSS FILE>`