### PR TITLE
fix: always accumulate_sizes when output is json or html

### DIFF
--- a/elf_size_analyze/__main__.py
+++ b/elf_size_analyze/__main__.py
@@ -84,7 +84,7 @@ def main():
         tree = SymbolsTreeByPath(symbols)
         if not args.no_merge_paths:
             tree.merge_paths(args.fish_paths)
-        if not args.no_cumulative_size:
+        if not args.no_cumulative_size or args.json or args.html:
             tree.accumulate_sizes()
         if args.sort_by_name:
             tree.sort(key=lambda symbol: symbol.name, reverse=False)


### PR DESCRIPTION
Closes https://github.com/jedrzejboczar/elf-size-analyze/issues/27.